### PR TITLE
Fix: SQL 예약어 사용했던 부분 수정

### DIFF
--- a/src/main/java/com/kkumteul/domain/book/entity/BookLike.java
+++ b/src/main/java/com/kkumteul/domain/book/entity/BookLike.java
@@ -20,7 +20,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Like {
+public class BookLike {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -39,7 +39,7 @@ public class Like {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Like(LikeType likeType, ChildProfile childProfile, Book book, LocalDateTime updatedAt) {
+    public BookLike(LikeType likeType, ChildProfile childProfile, Book book, LocalDateTime updatedAt) {
         this.likeType = likeType;
         this.childProfile = childProfile;
         this.book = book;

--- a/src/main/java/com/kkumteul/domain/survey/entity/MBTIAnswer.java
+++ b/src/main/java/com/kkumteul/domain/survey/entity/MBTIAnswer.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +22,7 @@ public class MBTIAnswer {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String option;
+    private String answerText;
     private int effectScore;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -29,8 +30,8 @@ public class MBTIAnswer {
     private MBTIQuestion question;
 
     @Builder
-    public MBTIAnswer(String option, int effectScore, MBTIQuestion question) {
-        this.option = option;
+    public MBTIAnswer(String answerText, int effectScore, MBTIQuestion question) {
+        this.answerText = answerText;
         this.effectScore = effectScore;
         this.question = question;
     }


### PR DESCRIPTION
기존에 like, option 예약어를 사용해 테이블이 제대로 생성되지 않았던 부분 수정

## ✅ 연관된 이슈

> ex) #6

## ✏️ 작업 내용

> SQL 예약어 (like, option) 사용한 필드가 테이블 정상 생성을 방해했던 부분 수정
Like 테이블 -> BookLike 테이블
MbtiAnswer의 option필드 -> answerText
변경

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

