### PR TITLE
Feat: 히스토리 논리/물리 삭제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.6.0'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
+	testImplementation 'org.springframework.batch:spring-batch-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kkumteul/config/DeleteHistoryBatchConfig.java
+++ b/src/main/java/com/kkumteul/config/DeleteHistoryBatchConfig.java
@@ -1,0 +1,54 @@
+package com.kkumteul.config;
+
+import com.kkumteul.domain.history.entity.ChildPersonalityHistory;
+import com.kkumteul.domain.history.repository.ChildPersonalityHistoryRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class DeleteHistoryBatchConfig {
+
+    private final ChildPersonalityHistoryRepository historyRepository;
+
+    @Bean
+    public Job deleteHistoryJob(JobRepository jobRepository, Step deleteHistoryStep) {
+        return new JobBuilder("deleteHistoryJob", jobRepository)
+                .start(deleteHistoryStep)
+                .build();
+    }
+
+    @Bean
+    public Step deleteHistoryStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("deleteHistoryStep", jobRepository)
+                .tasklet((contribution, chunkContext) -> {
+                    log.info("run deleteHistory tasklet");
+                    LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
+                    List<ChildPersonalityHistory> historiesToDelete = historyRepository.findAllByRealDelete(oneMonthAgo);
+                    historyRepository.deleteAll(historiesToDelete);
+                    return RepeatStatus.FINISHED;
+                }, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager(DataSource dataSource) {
+        return new DataSourceTransactionManager(dataSource);
+    }
+}

--- a/src/main/java/com/kkumteul/config/scheduler/DeleteHistoryScheduler.java
+++ b/src/main/java/com/kkumteul/config/scheduler/DeleteHistoryScheduler.java
@@ -1,0 +1,36 @@
+package com.kkumteul.config.scheduler;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Slf4j
+@EnableScheduling
+@Configuration
+@RequiredArgsConstructor
+public class DeleteHistoryScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job deleteHistoryJob;
+
+    @Scheduled(cron = "0 0 4 * * ?") // 매일 새벽 4시에 실행
+    public void runDeleteHistoryJob() {
+        log.info("delete history job time: {}", LocalDateTime.now());
+
+        try {
+            JobParameters params = new JobParametersBuilder()
+                    .addString("DeleteHistoryJob", String.valueOf(System.currentTimeMillis()))
+                    .toJobParameters();
+            jobLauncher.run(deleteHistoryJob, params);
+        } catch (Exception e) {
+            log.error("Error", e);
+        }
+    }
+}

--- a/src/main/java/com/kkumteul/domain/history/controller/ChildPersonalityHistoryController.java
+++ b/src/main/java/com/kkumteul/domain/history/controller/ChildPersonalityHistoryController.java
@@ -1,0 +1,25 @@
+package com.kkumteul.domain.history.controller;
+
+import com.kkumteul.domain.history.service.ChildPersonalityHistoryService;
+import com.kkumteul.util.ApiUtil;
+import com.kkumteul.util.ApiUtil.ApiSuccess;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/history")
+public class ChildPersonalityHistoryController {
+
+    private final ChildPersonalityHistoryService historyService;
+
+    @DeleteMapping("/{historyId}")
+    public ApiSuccess<?> deleteHistory(@PathVariable(name = "historyId") Long historyId) {
+        historyService.deleteHistory(historyId);
+
+        return ApiUtil.success("히스토리가 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/kkumteul/domain/history/entity/ChildPersonalityHistory.java
+++ b/src/main/java/com/kkumteul/domain/history/entity/ChildPersonalityHistory.java
@@ -81,6 +81,11 @@ public class ChildPersonalityHistory {
         favoriteTopic.setHistory(this);
     }
 
+    public void delete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+
     public List<FavoriteGenre> getFavoriteGenres() {
         return Collections.unmodifiableList(favoriteGenres);
     }

--- a/src/main/java/com/kkumteul/domain/history/repository/ChildPersonalityHistoryRepository.java
+++ b/src/main/java/com/kkumteul/domain/history/repository/ChildPersonalityHistoryRepository.java
@@ -1,6 +1,7 @@
 package com.kkumteul.domain.history.repository;
 
 import com.kkumteul.domain.history.entity.ChildPersonalityHistory;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,6 +19,9 @@ public interface ChildPersonalityHistoryRepository extends JpaRepository<ChildPe
     Optional<ChildPersonalityHistory> findHistoryByChildProfileIdAndHistoryCreatedType(Long childProfileId,
                                                                                        HistoryCreatedType historyCreatedType);
   
-    @Query("SELECT h FROM ChildPersonalityHistory  h JOIN FETCH h.mbtiScore ms JOIN FETCH ms.mbti m WHERE h.childProfile.id = :childProfileId")
+    @Query("SELECT h FROM ChildPersonalityHistory  h JOIN FETCH h.mbtiScore ms JOIN FETCH ms.mbti m WHERE h.childProfile.id = :childProfileId AND h.isDeleted = false")
     List<ChildPersonalityHistory> findHistoryWithMBTIByChildProfileId(@Param("childProfileId") Long childProfileId);
+
+    @Query("SELECT h FROM ChildPersonalityHistory h WHERE h.isDeleted = true AND h.deletedAt < :dateTime")
+    List<ChildPersonalityHistory> findAllByRealDelete(@Param("dateTime") LocalDateTime dateTime);
 }

--- a/src/main/java/com/kkumteul/domain/history/service/ChildPersonalityHistoryService.java
+++ b/src/main/java/com/kkumteul/domain/history/service/ChildPersonalityHistoryService.java
@@ -94,4 +94,14 @@ public class ChildPersonalityHistoryService {
 
         history.addFavoriteTopic(favoriteTopic);
     }
+
+    @Transactional
+    public void deleteHistory(Long historyId) {
+        log.info("delete History Id: {}", historyId);
+
+        ChildPersonalityHistory history = historyRepository.findById(historyId)
+                .orElseThrow(() -> new HistoryNotFoundException(historyId));
+
+        history.delete();
+    }
 }

--- a/src/test/java/com/kkumteul/batch/DeleteHistoryBatchConfigTest.java
+++ b/src/test/java/com/kkumteul/batch/DeleteHistoryBatchConfigTest.java
@@ -1,0 +1,72 @@
+package com.kkumteul.batch;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import com.kkumteul.config.DeleteHistoryBatchTestConfig;
+import com.kkumteul.config.scheduler.DeleteHistoryScheduler;
+import com.kkumteul.domain.history.entity.ChildPersonalityHistory;
+import com.kkumteul.domain.history.repository.ChildPersonalityHistoryRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.batch.test.context.SpringBatchTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootTest
+@ExtendWith(MockitoExtension.class)
+@SpringBatchTest
+public class DeleteHistoryBatchConfigTest {
+
+    @MockBean
+    private ChildPersonalityHistoryRepository historyRepository;
+
+    @Autowired
+    private JobLauncherTestUtils jobLauncherTestUtils;
+
+    @Autowired
+    private DeleteHistoryScheduler deleteHistoryScheduler;
+
+    @Test
+    @DisplayName("배치 작업 테스트")
+    public void testDeleteHistoryJob() throws Exception {
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
+        List<ChildPersonalityHistory> histories = new ArrayList<>();
+
+        given(historyRepository.findAllByRealDelete(oneMonthAgo)).willReturn(histories);
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("JobID", String.valueOf(System.currentTimeMillis()))
+                .toJobParameters();
+
+        //배치 작업 직접 실행 (jobParameter 전달)
+        JobExecution jobExecution = jobLauncherTestUtils.getJobLauncher().run(jobLauncherTestUtils.getJob(), jobParameters);
+
+        assertThat(jobExecution.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        verify(historyRepository, times(1)).deleteAll(histories);
+    }
+
+    @Test
+    @DisplayName("스케줄러 메서드 수행 테스트")
+    public void testSchedulerJobExecution() throws Exception {
+        //4시까지 기다리지 않고 스케줄러 메서드를 수동으로 실행한다.
+        deleteHistoryScheduler.runDeleteHistoryJob();
+
+        verify(historyRepository, atLeastOnce()).findAllByRealDelete(any(LocalDateTime.class));
+        verify(historyRepository, atLeastOnce()).deleteAll(anyList());
+    }
+}

--- a/src/test/java/com/kkumteul/config/DeleteHistoryBatchTestConfig.java
+++ b/src/test/java/com/kkumteul/config/DeleteHistoryBatchTestConfig.java
@@ -1,0 +1,19 @@
+package com.kkumteul.config;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.test.JobLauncherTestUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootTest
+@TestConfiguration
+public class DeleteHistoryBatchTestConfig {
+
+    @Bean
+    public JobLauncherTestUtils jobLauncherTestUtils(Job deleteHistoryJob) {
+        JobLauncherTestUtils jobLauncherTestUtils = new JobLauncherTestUtils();
+        jobLauncherTestUtils.setJob(deleteHistoryJob);
+        return jobLauncherTestUtils;
+    }
+}


### PR DESCRIPTION
## ✅ 연관된 이슈

> ex) #28 

## ✏️ 작업 내용

> 진단 히스토리의 논리 삭제 API를 구현했습니다.

> 진단 히스토리의 물리 삭제는 배치/스케줄러를 통해 매일 새벽 4시에 수행되도록 구현하였습니다.

> 배치/스케줄러 작업에 사용된 Repository, Service, Controller 테스트는 작성 필요.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)