### PR TITLE
Refactor: MBTI 설문 점수 부여 방식 수정 및 프로필 변경 수정

### DIFF
--- a/src/main/java/com/kkumteul/domain/childprofile/service/PersonalityScoreService.java
+++ b/src/main/java/com/kkumteul/domain/childprofile/service/PersonalityScoreService.java
@@ -86,6 +86,7 @@ public class PersonalityScoreService {
         CumulativeMBTIScore cumulativeScore = cumulativeMBTIScoreRepository.findByChildProfileId(childProfileId)
                 .orElseThrow(() -> new IllegalArgumentException("점수가 존재하지 않습니다."));
 
+        cumulativeScore.resetScores();
         return cumulativeScore.updateScores(mbtiScore);
     }
 }

--- a/src/main/java/com/kkumteul/domain/history/service/ChildPersonalityHistoryService.java
+++ b/src/main/java/com/kkumteul/domain/history/service/ChildPersonalityHistoryService.java
@@ -18,12 +18,14 @@ import com.kkumteul.domain.personality.repository.TopicRepository;
 import com.kkumteul.exception.ChildProfileNotFoundException;
 import com.kkumteul.exception.EntityNotFoundException;
 import com.kkumteul.exception.HistoryNotFoundException;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
@@ -35,14 +37,17 @@ public class ChildPersonalityHistoryService {
     private final ChildProfileRepository childProfileRepository;
     private final GenreRepository genreRepository;
     private final TopicRepository topicRepository;
+    private final EntityManager entityManager;
 
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void deleteDiagnosisHistory(Long childProfileId) {
         Optional<ChildPersonalityHistory> diagnosisHistory = historyRepository.findHistoryByChildProfileIdAndHistoryCreatedType(
                 childProfileId, HistoryCreatedType.DIAGNOSIS);
 
-        diagnosisHistory.ifPresent(historyRepository::delete);
+        diagnosisHistory.ifPresent(history -> {
+            historyRepository.delete(history);
+        });
     }
 
     @Transactional

--- a/src/main/java/com/kkumteul/domain/mbti/service/MBTIService.java
+++ b/src/main/java/com/kkumteul/domain/mbti/service/MBTIService.java
@@ -32,30 +32,41 @@ public class MBTIService {
         int jScore = 0;
 
         for (MBTISurveyAnswerDto answer : answers) {
+            int score = answer.getScore();
+            int adjustment = score - 4;
+
             switch (answer.getMbtiEffect()) {
                 case "I":
-                    iScore += answer.getScore();
+                    iScore += Math.max(adjustment, 0); // 5-7점: I 증가
+                    eScore += Math.max(-adjustment, 0); // 1-3점: E 증가
                     break;
                 case "E":
-                    eScore += answer.getScore();
+                    eScore += Math.max(adjustment, 0);
+                    iScore += Math.max(-adjustment, 0);
                     break;
                 case "S":
-                    sScore += answer.getScore();
+                    sScore += Math.max(adjustment, 0);
+                    nScore += Math.max(-adjustment, 0);
                     break;
                 case "N":
-                    nScore += answer.getScore();
+                    nScore += Math.max(adjustment, 0);
+                    sScore += Math.max(-adjustment, 0);
                     break;
                 case "T":
-                    tScore += answer.getScore();
+                    tScore += Math.max(adjustment, 0);
+                    fScore += Math.max(-adjustment, 0);
                     break;
                 case "F":
-                    fScore += answer.getScore();
+                    fScore += Math.max(adjustment, 0);
+                    tScore += Math.max(-adjustment, 0);
                     break;
                 case "J":
-                    jScore += answer.getScore();
+                    jScore += Math.max(adjustment, 0);
+                    pScore += Math.max(-adjustment, 0);
                     break;
                 case "P":
-                    pScore += answer.getScore();
+                    pScore += Math.max(adjustment, 0);
+                    jScore += Math.max(-adjustment, 0);
                     break;
                 default:
                     throw new IllegalArgumentException("Invalid MBTI effect: " + answer.getMbtiEffect());

--- a/src/main/java/com/kkumteul/domain/survey/service/pattern/SurveyFacadeImpl.java
+++ b/src/main/java/com/kkumteul/domain/survey/service/pattern/SurveyFacadeImpl.java
@@ -49,7 +49,7 @@ public class SurveyFacadeImpl implements SurveyFacade {
         누적 점수를 바탕으로 선호 장르/주제어를 저장한다.
          */
         MBTIScore mbtiScore = mbtiService.calculateMBTIScore(requestDto.getAnswers());
-        personalityScoreService.resetCumulativeMBTIScore(childProfileId);
+//        personalityScoreService.resetCumulativeMBTIScore(childProfileId);
         personalityScoreService.updateCumulativeMBTIScore(childProfileId, mbtiScore);
 
         personalityScoreService.resetFavoriteScores(childProfileId);

--- a/src/main/java/com/kkumteul/domain/survey/service/pattern/SurveyFacadeImpl.java
+++ b/src/main/java/com/kkumteul/domain/survey/service/pattern/SurveyFacadeImpl.java
@@ -37,6 +37,8 @@ public class SurveyFacadeImpl implements SurveyFacade {
     public SurveyResultDto submitSurvey(SurveyResultRequestDto requestDto, Long childProfileId) {
         log.info("Submit survey Input childProfileId: {}", childProfileId);
 
+        historyService.deleteDiagnosisHistory(childProfileId);
+
         ChildProfile childProfile = childProfileService.getChildProfile(childProfileId);
         /*
         진단 시 누적 점수는 초기화된다.
@@ -54,7 +56,6 @@ public class SurveyFacadeImpl implements SurveyFacade {
         personalityScoreService.updateFavoriteGenresScore(childProfile, requestDto.getFavoriteGenres());
         personalityScoreService.updateFavoriteTopicsScore(childProfile, requestDto.getFavoriteTopics());
 
-        historyService.deleteDiagnosisHistory(childProfileId);
         ChildPersonalityHistory latestHistory = historyService.createHistory(childProfileId, mbtiScore,
                 HistoryCreatedType.DIAGNOSIS);
 


### PR DESCRIPTION
## ✅ 연관된 이슈

> ex) #43 

## ✏️ 작업 내용

> MBTI 설문 점수 부여 방식 수정 (중간 점수를 기준으로 해당 점수보다 아래인 경우 반대 MBTI 점수에 영향, 아닐 경우 원래 MBTI 점수에 영향을 주는 방식)

> 트랜잭션 범위를 수정하며 발생한 오류 수정 -> 히스토리 생성 후 즉각 삭제했던 부분 / update 쿼리가 중복 발생했던 부분 수정

> 프로필 변경 방식 수정 사항 추가 예정

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
