### PR TITLE
Refactor: 좋아요/싫어요에 카프카 메시지 로직 추가, 성향 변경에 MBTI 반영

### DIFF
--- a/src/main/java/com/kkumteul/config/ChangePersonalityBatchConfig.java
+++ b/src/main/java/com/kkumteul/config/ChangePersonalityBatchConfig.java
@@ -3,6 +3,7 @@ package com.kkumteul.config;
 import static com.kkumteul.util.redis.RedisKey.*;
 
 import com.kkumteul.domain.book.entity.Book;
+import com.kkumteul.domain.book.entity.BookMBTI;
 import com.kkumteul.domain.book.service.BookService;
 import com.kkumteul.domain.childprofile.entity.ChildProfile;
 import com.kkumteul.domain.childprofile.entity.GenreScore;
@@ -88,9 +89,11 @@ public class ChangePersonalityBatchConfig {
 
             ChildProfile childProfile = childProfileService.getChildProfileWithMBTIScore(childProfileId);
             Book book = bookService.getBook(bookId);
+            List<BookMBTI> bookMBTIS = book.getBookMBTIS();
 
             double changedScore = action.equals("LIKE") ? 2.0 : -2.0;
             personalityScoreService.updateGenreAndTopicScores(childProfile, book, changedScore);
+            personalityScoreService.updateCumulativeMBTIScore(childProfileId, bookMBTIS, changedScore);
 
             return childProfileId;
         };

--- a/src/main/java/com/kkumteul/domain/childprofile/entity/CumulativeMBTIScore.java
+++ b/src/main/java/com/kkumteul/domain/childprofile/entity/CumulativeMBTIScore.java
@@ -2,6 +2,7 @@ package com.kkumteul.domain.childprofile.entity;
 
 import com.kkumteul.domain.history.entity.MBTIScore;
 import com.kkumteul.domain.mbti.entity.MBTI;
+import com.kkumteul.domain.mbti.entity.MBTIName;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -76,6 +77,48 @@ public class CumulativeMBTIScore {
         this.pScore += mbtiScore.getPScore();
 
         return this;
+    }
+
+    public void updateScores(MBTI mbti, double changeScore) {
+        MBTIName mbtiString = mbti.getMbti();
+
+        char[] mbtiChars = mbtiString.name().toCharArray();
+
+        for (char mbtiChar : mbtiChars) {
+            switch (mbtiChar) {
+                case 'I':
+                    this.iScore += changeScore;
+                    break;
+
+                case 'E':
+                    this.eScore += changeScore;
+                    break;
+
+                case 'S':
+                    this.sScore += changeScore;
+                    break;
+
+                case 'N':
+                    this.nScore += changeScore;
+                    break;
+
+                case 'T':
+                    this.tScore += changeScore;
+                    break;
+
+                case 'F':
+                    this.fScore += changeScore;
+                    break;
+
+                case 'J':
+                    this.jScore += changeScore;
+                    break;
+
+                case 'P':
+                    this.pScore += changeScore;
+                    break;
+            }
+        }
     }
 
     public void resetScores() {

--- a/src/main/java/com/kkumteul/domain/childprofile/service/PersonalityScoreService.java
+++ b/src/main/java/com/kkumteul/domain/childprofile/service/PersonalityScoreService.java
@@ -1,6 +1,7 @@
 package com.kkumteul.domain.childprofile.service;
 
 import com.kkumteul.domain.book.entity.Book;
+import com.kkumteul.domain.book.entity.BookMBTI;
 import com.kkumteul.domain.book.entity.BookTopic;
 import com.kkumteul.domain.childprofile.entity.ChildProfile;
 import com.kkumteul.domain.childprofile.entity.CumulativeMBTIScore;
@@ -10,6 +11,7 @@ import com.kkumteul.domain.childprofile.repository.CumulativeMBTIScoreRepository
 import com.kkumteul.domain.childprofile.repository.GenreScoreRepository;
 import com.kkumteul.domain.childprofile.repository.TopicScoreRepository;
 import com.kkumteul.domain.history.entity.MBTIScore;
+import com.kkumteul.domain.mbti.entity.MBTI;
 import com.kkumteul.domain.personality.entity.Genre;
 import com.kkumteul.domain.personality.entity.Topic;
 import com.kkumteul.exception.EntityNotFoundException;
@@ -95,6 +97,18 @@ public class PersonalityScoreService {
     }
 
     @Transactional
+    public void updateCumulativeMBTIScore(Long childProfileId, List<BookMBTI> bookMBTIS, double changeScore) {
+        log.info("Update CumulativeMBTIScore ChildProfile ID: {}", childProfileId);
+        CumulativeMBTIScore cumulativeScore = cumulativeMBTIScoreRepository.findByChildProfileId(childProfileId)
+                .orElseThrow(() -> new IllegalArgumentException("점수가 존재하지 않습니다."));
+
+        for (BookMBTI bookMBTI : bookMBTIS) {
+            MBTI mbti = bookMBTI.getMbti();
+            cumulativeScore.updateScores(mbti, changeScore);
+        }
+    }
+
+    @Transactional
     public void updateGenreAndTopicScores(ChildProfile childProfile, Book book, double changedScore) {
         Genre genre = book.getGenre();
         List<BookTopic> bookTopics = book.getBookTopics();
@@ -112,4 +126,6 @@ public class PersonalityScoreService {
 
         log.info("Update Genre and Topic scores - ChildProfile ID: {}", childProfile.getId());
     }
+
+
 }


### PR DESCRIPTION
## ✅ 연관된 이슈

> #48 

## ✏️ 작업 내용

> 민아님 도서 좋아요/싫어요 로직에 이벤트 관리를 위한 카프카 메시지 발행 로직 추가.

> 성향 변경에 도서 MBTI 정보 반영해 MBTI 정보도 변경.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

