### PR TITLE
Fix: 테스트용 DB 사용을 위해 ActiveProfiles 어노테이션 추가

### DIFF
--- a/src/test/java/com/kkumteul/domain/adminbook/controller/AdminBookControllerTest.java
+++ b/src/test/java/com/kkumteul/domain/adminbook/controller/AdminBookControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@ActiveProfiles("test")
 @WebMvcTest(AdminBookController.class)
 public class AdminBookControllerTest {
 


### PR DESCRIPTION
## ✅ 연관된 이슈

> #58

## ✏️ 작업 내용

> ActiveProfiles 를 추가함으로써 test용 DB 사용을 명시하였습니다.

### 스크린샷
![image](https://github.com/user-attachments/assets/db7865b3-b8ce-422b-b5a7-8c43b1e93aeb)

## 💬 리뷰 요구사항(선택)
